### PR TITLE
Removed sharedKeyVaulCertificates

### DIFF
--- a/Resources/parameters.json
+++ b/Resources/parameters.json
@@ -79,9 +79,6 @@
     },
     "threatDetectionEmailAddress": {
       "value": __threatDetectionEmailAddress__
-    },
-    "certificates": {
-      "value": __certificates__
     }
   }
 }

--- a/Resources/template.json
+++ b/Resources/template.json
@@ -134,13 +134,6 @@
         "description": "The email address that threat alerts will be sent to"
       }
     },
-    "certificates": {
-      "type": "array",
-      "defaultValue": [],
-      "metadata": {
-        "description": "Array of certificates (must exist in keyvault)"
-      }
-    },
     "virtualNetworkPrefix": {
       "type": "string",
       "metadata": {
@@ -222,30 +215,6 @@
         "parameters": {
           "keyVaultName": {
             "value": "[variables('keyVaultName')]"
-          }
-        }
-      }
-    },
-    {
-      "name": "sharedKeyVaultCertificates",
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2017-05-10",
-      "condition": "[greater(length(parameters('certificates')), 0)]",
-      "dependsOn": [
-        "sharedKeyVault"
-      ],
-      "properties": {
-        "mode": "Incremental",
-        "templateLink": {
-          "uri": "[concat(variables('dfcDevOpsTemplatesUrl'),'keyvault-certificates.json')]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "keyVaultName": {
-            "value": "[variables('keyVaultName')]"
-          },
-          "certificates": {
-            "value": "[parameters('certificates')]"
           }
         }
       }
@@ -367,7 +336,6 @@
     {
       "name": "sharedApimKeyVaultAccessPolicy",
       "type": "Microsoft.Resources/deployments",
-      "condition": "[greater(length(parameters('certificates')), 0)]",
       "apiVersion": "2017-05-10",
       "properties": {
         "mode": "Incremental",
@@ -420,7 +388,7 @@
     {
       "name": "sharedApimServiceBasic",
       "type": "Microsoft.Resources/deployments",
-      "condition": "[and(not(parameters('apimExists')), greater(length(parameters('certificates')), 0))]",
+      "condition": "[not(parameters('apimExists'))]",
       "apiVersion": "2017-05-10",
       "properties": {
         "mode": "Incremental",
@@ -447,7 +415,6 @@
     {
       "name": "sharedApimServiceFull",
       "type": "Microsoft.Resources/deployments",
-      "condition": "[greater(length(parameters('certificates')), 0)]",
       "apiVersion": "2017-05-10",
       "properties": {
         "mode": "Incremental",

--- a/Resources/test-parameters.json
+++ b/Resources/test-parameters.json
@@ -89,9 +89,6 @@
     },
     "threatDetectionEmailAddress": {
       "value": []
-    },
-    "certificates": {
-      "value": []
     }
   }
 }


### PR DESCRIPTION
Further investigation revealed that this is not being used and is no longer required.
Removed from template and parameter files.
Removed dependcy calls using it.