### PR TITLE
NCSD-3394: apim scale fix

### DIFF
--- a/Resources/template.json
+++ b/Resources/template.json
@@ -768,6 +768,9 @@
           "skuTier": {
             "value": "[parameters('apimSkuTier')]"
           },
+          "capacity": {
+            "value": "[parameters('apimCapacity')]"
+          },
           "subnetName": {
             "value": "[parameters('apimSubnetName')]"
           },


### PR DESCRIPTION
apimCapacity is getting passed into sharedApimServiceBasic but not sharedApimServiceFull.  sharedApimServiceBasic  only runs on the first deployment so it's more important that it goes on sharedApimServiceFull